### PR TITLE
Handle pre-existing branch in add-aircraft workflow

### DIFF
--- a/.github/workflows/add-aircraft-from-issue.yml
+++ b/.github/workflows/add-aircraft-from-issue.yml
@@ -295,6 +295,7 @@ jobs:
         run: |
           ICAO="${{ steps.parse.outputs.icao }}"
           BRANCH="feat/add-aircraft-${ICAO}-${{ steps.parse.outputs.issue_number }}"
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Delete the remote feature branch before pushing if it already exists. Prevents "reference already exists" errors when the workflow re-triggers on the same issue (e.g. re-labeling).