### PR TITLE
Use aircraft-ready label as explicit workflow trigger

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-aircraft-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-aircraft-request.yml
@@ -10,7 +10,10 @@ body:
     attributes:
       value: |
         ## New Aircraft Request
-        The workflow will automatically validate weights against local data and the SimBrief database.
+        Fill out the form below. Once submitted, a staff member will review and add the
+        `aircraft-ready` label to trigger the automated addition workflow.
+
+        The workflow will validate weights against local data and the SimBrief database.
         If the aircraft is **not** found in SimBrief, provide a custom profile URL below.
 
   - type: input

--- a/.github/workflows/add-aircraft-from-issue.yml
+++ b/.github/workflows/add-aircraft-from-issue.yml
@@ -2,16 +2,20 @@ name: Add Aircraft from Issue
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
 
+concurrency:
+  group: add-aircraft-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   add-aircraft:
-    if: contains(github.event.issue.labels.*.name, 'aircraft')
+    if: github.event.label.name == 'aircraft-ready'
     runs-on: ubuntu-latest
     environment: flight-gen
 


### PR DESCRIPTION
- Workflow now fires only when staff adds the aircraft-ready label, not on issue open or other labels being applied
- Add concurrency group per issue so re-labeling cannot queue a second run
- Issue template updated to explain the staff review step