### PR TITLE
Bump urllib3 2.5.0 → 2.6.3 to fix CVE-2026-21441, CVE-2025-66418, CVE…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ certifi==2025.10.5
 charset-normalizer==3.4.4
 idna==3.11
 requests==2.32.5
-urllib3==2.5.0
+urllib3==2.6.3
 geopy==2.4.1


### PR DESCRIPTION
…-2025-66471